### PR TITLE
Consolidate concurrent CLI around core runner

### DIFF
--- a/metamorph/mainConcurrent.py
+++ b/metamorph/mainConcurrent.py
@@ -1,337 +1,67 @@
 from __future__ import annotations
 
-from typing import Dict, List, Union, Optional
-from pydantic import BaseModel
-import asyncio
-from dataclasses import dataclass
-from datetime import datetime, timezone
-import sys
-import os
-import pandas as pd
-from pathlib import Path
-from langgraph.graph import StateGraph
-#from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 import argparse
-
-
-
-
-
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-
-from supervisor import supervisor_node
-from schema_inference import schema_inference_node
-from meta_parser import parser_node
-from refinement import refinement_agent
-from validator import validator_node
-from imagoScribe import summarizeTransformations
-
-
-from utils.llm import set_llm_model, get_llm
-from utils.thread import generate_thread_id
-from utils.MetaMorphState import tracker, MetaMorphState, InputColumnData
-from utils.tools import get_key, get_attr_or_item
-from utils.ScribeTemplate import html_template
-from input import build_sample_data
-
-
-
-
-JSONScalar = Union[str, int, float, bool, None]
-DEFAULT_OUTDIR = "Reports"
-
-class FinalDataSummary(BaseModel):
-    trackerInfo: tracker
-    confidence: float
-    ColNames: Dict[str, List[str]]
-    TransformedValues: List[List[JSONScalar]]
-    error: Optional[str] = None
-
-class DatasetSummary(BaseModel):
-    dataset_id: str
-    started_at: str
-    finished_at: str
-    n_success: int
-    n_failed: int
-    colData: Dict[str, FinalDataSummary]
-
-@dataclass
-class MetaMorphResults:
-    dataset_id: str
-    model: str
-    stamp: str
-    report_md_path: str
-    report_html_path: str
-    cleaned_csv_path: str
-    report_md_preview: str
-
-
-async def colRunner(app, dataset_id: str, col_name: str, col_values: list, col_sample):
-    init = MetaMorphState(
-        input_column_data=InputColumnData(
-            column_name=col_name,
-            values=col_values),
-        ColumnSample=col_sample,
-    )
-    thread_id = generate_thread_id(dataset_id)
-    config = {"configurable": {"thread_id": f"{thread_id}:{col_name}"}}
-
-    FinalState = await app.ainvoke(init, config=config)
-
-    try:
-
-        ParsedOut = get_key(FinalState, "parsed_data_output")
-        Refined = get_key(FinalState, "refinement_results")
-        TrackerInfo = get_key(FinalState, "Node_Col_Tracker")
-
-
-        ColumnNames = get_attr_or_item(ParsedOut, "column_name")
-        TransformedData = get_attr_or_item(Refined, "cleaned_values")
-        ModelConfidence = get_attr_or_item(Refined, "confidence", 0.0)
-        
-        #print(f"ColNames: {ColumnNames}\n")
-        ColumnNames 
-
-        return FinalDataSummary(
-            trackerInfo=TrackerInfo,
-            confidence=ModelConfidence,
-            ColNames=ColumnNames,
-            TransformedValues=TransformedData,
-        )
-
-    except Exception as e:
-        return FinalDataSummary(
-            trackerInfo=tracker(),
-            confidence=0.0,
-            ColNames={col_name: []}, #double check later
-            TransformedValues=[],
-            error=f"{type(e).__name__}: {e}",
-        )
-    
-async def run_all(graph, dataset_id: str, columns: Dict[str, list], max_concurrency=5) -> DatasetSummary:
-
-    #cp = AsyncSqliteSaver.from_conn_string("metamorph.db")
-
-    #async with cp as checkpointer:
-        #app = graph.compile(checkpointer=checkpointer)
-    app = graph.compile()
-    sem = asyncio.Semaphore(max_concurrency)
-        
-    StartTime = datetime.now(timezone.utc).isoformat()
-
-    async def _colTask(col, val):
-        async with sem:
-            #inserting panda series for each column
-            series_data = pd.Series(val, name=col)
-
-            col_sample = build_sample_data(series_data)
-
-            try:
-                summary = await colRunner(app, dataset_id, col, val, col_sample)
-                return col, summary
-            except Exception as e:
-                return col, e
-            
-    results = await asyncio.gather(*[_colTask(c, v) for c, v in columns.items()])
-
-    col_summaries: Dict[str, FinalDataSummary] = {}
-    n_success = 0
-    n_failed = 0
-
-    for col, out in results:
-        if isinstance(out, Exception):
-            n_failed += 1
-            col_summaries[col] = FinalDataSummary(
-                trackerInfo=tracker(),
-                confidence=0.0,
-                ColNames={col: []},
-                TransformedValues=[],
-                error=f"{type(out).__name__}: {out}",
-            )
-            continue
-    
-        summary = out
-        col_summaries[col] = summary
-        if summary.error:
-            n_failed += 1
-        else:
-            n_success += 1
-
-    EndTime = datetime.now(timezone.utc).isoformat()
-
-    return DatasetSummary(
-        dataset_id=dataset_id,
-        started_at=StartTime,
-        finished_at=EndTime,
-        n_success=n_success,
-        n_failed=n_failed,
-        colData=col_summaries,
-    )
-
-
-# Final DF builder
-def BuildFinalDf(df: pd.DataFrame, cleaned_data: DatasetSummary):
-    """
-    Building a final dataframe after transformation
-
-    Key Rules Applied Here:
-    - Failed columns are replaced with originals 
-    - Missing column names will be replaced with originals 
-    - Ensures number of rows are matching 
-    """
-
-    n_rows = len(df)
-    out = pd.DataFrame(index=df.index)
-
-    for col in df.columns:
-        ColSumm = cleaned_data.colData.get(col)
-
-        if ColSumm is None or ColSumm.error:
-            out[col] = df[col]
-            continue
-
-        Transformed = ColSumm.TransformedValues or []
-        k = len(Transformed)
-
-        if k == 0:
-            out[col] = df[col]
-            continue
-
-        names = (ColSumm.ColNames.get(col) if ColSumm.ColNames else None) or []
-        if len(names) != k:
-            names = [f"{col}__{i + 1}" for i in range(k)]
-
-        for i in range(k):
-            vals = Transformed[i] if i < len(Transformed) else []
-
-            if len(vals) < n_rows:
-                vals = vals + [None]*(n_rows - len(vals))
-                print("Mismatch in row number, less in transfomed")
-
-            elif len(vals) > n_rows:
-                vals = vals[:n_rows]
-                print("Mismatch in row number, more in transfomed")
-
-            out[names[i]] = vals
-
-    return out
-
-
-def run_MetaMorph_on_csv(
-    input_path: str,
-    outdir: str | Path = DEFAULT_OUTDIR,
-    dataset_id: str | None = None,
-    llm: str = "gpt-5-nano",
-    max_concurrency: int = 2,    
-) -> MetaMorphResults:
-    
-    input_path = Path(input_path).resolve()
-    if not input_path.exists():
-        raise FileNotFoundError(f"Input file not found: {input_path}")
-    
-    outdir = Path(outdir).resolve()
-    outdir.mkdir(parents=True, exist_ok=True)
-
-
-    set_llm_model(llm)
-    model_name = get_llm().model_name
-    print("Using model:", model_name)
-
-    graph = StateGraph(MetaMorphState)
-
-    graph.add_node("supervisor", supervisor_node)
-    graph.add_node("schemaInference", schema_inference_node)
-    graph.add_node("parser_agent", parser_node)
-    graph.add_node("refinement_agent", refinement_agent)
-    graph.add_node("validator_agent", validator_node)
-
-    graph.set_entry_point("supervisor")
-
-    # Loading the CSV
-    df = pd.read_csv(input_path)
-    columns = {col: df[col].tolist() for col in df.columns}
-
-    dataset_id = dataset_id or input_path.stem
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-
-    # Running METAMORPH on all columns 
-    cleaned_data = asyncio.run(
-        run_all(
-            graph=graph,
-            dataset_id=dataset_id,
-            columns=columns,
-            max_concurrency=max_concurrency,
-        )
-    )
-
-    report_md = summarizeTransformations(cleaned_data.model_dump())
-
-    report_md_path = outdir / f"MetaMorph_Report_{stamp}.md"
-    report_html_path = outdir / f"MetaMorph_Report_{stamp}.html"
-    cleaned_csv_path = outdir / f"MetaMorph_Cleaned_{stamp}.csv"
-
-    report_md_path.write_text(report_md, encoding="utf-8")
-
-    html_report = html_template.render(**cleaned_data.model_dump())
-    report_html_path.write_text(html_report, encoding="utf-8")
-
-    cleaned_df = BuildFinalDf(df, cleaned_data)
-    cleaned_df.to_csv(cleaned_csv_path, index=False)
-
-    return MetaMorphResults(
-        dataset_id=dataset_id,
-        model=model_name,
-        stamp=stamp,
-        report_md_path=str(report_md_path),
-        report_html_path=str(report_html_path),
-        cleaned_csv_path=str(cleaned_csv_path),
-        report_md_preview=report_md[:1200],
-    )
-
-    
-
-
-
-#Implementing file parsing logic 
-if __name__ == "__main__":
-
+import sys
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from metamorph.core import DEFAULT_OUTDIR, run_MetaMorph_on_csv
+except ModuleNotFoundError:
+    # Support the documented direct script form:
+    # `python metamorph/mainConcurrent.py ...`
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from metamorph.core import DEFAULT_OUTDIR, run_MetaMorph_on_csv
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Run MetaMorph concurrently on a dataset and generated a report."
+        description="Run MetaMorph concurrently on a dataset and generate a report."
     )
-
     parser.add_argument(
-        "--input", "-i",
+        "--input",
+        "-i",
         required=True,
-        help="Path to CSV file to process."
-    )
-
-    parser.add_argument(
-        "--dataset-id", "-d",
-        help="Optional dataset identifier. Defaults to the input filename stem."
+        help="Path to CSV file to process.",
     )
     parser.add_argument(
-        "--outdir", "-o",
+        "--dataset-id",
+        "-d",
+        help="Optional dataset identifier. Defaults to the input filename stem.",
+    )
+    parser.add_argument(
+        "--outdir",
+        "-o",
         default=DEFAULT_OUTDIR,
-        help=f"Output directory for the generated report files. Defaults to {DEFAULT_OUTDIR}/."
+        help=f"Output directory for the generated report files. Defaults to {DEFAULT_OUTDIR}/.",
     )
     parser.add_argument(
-        "--llm", "-l",
+        "--llm",
+        "-l",
         type=str,
         default="gpt-5-nano",
-        help="OpenAI LLM model to use"
+        help="OpenAI LLM model to use.",
     )
     parser.add_argument(
         "--max-concurrency",
         type=int,
         default=2,
-        help="Maximum number of columns to process concurrently."
+        help="Maximum number of columns to process concurrently.",
     )
-    args = parser.parse_args()
+    return parser
 
-    res = run_MetaMorph_on_csv(
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    run_MetaMorph_on_csv(
         input_path=args.input,
         outdir=args.outdir,
         dataset_id=args.dataset_id,
         llm=args.llm,
         max_concurrency=args.max_concurrency,
     )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_core_runner.py
+++ b/tests/test_core_runner.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pandas as pd
 
 from metamorph import core
+from metamorph import mainConcurrent
 from metamorph import mcp_server
 from utils.MetaMorphState import tracker
 
@@ -124,6 +125,32 @@ class CliTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertIn("--outdir", completed.stdout)
         self.assertIn("Defaults to Reports/", completed.stdout)
+
+    def test_concurrent_cli_delegates_to_core_runner(self):
+        with patch.object(mainConcurrent, "run_MetaMorph_on_csv") as run_csv:
+            exit_code = mainConcurrent.main(
+                [
+                    "--input",
+                    "examples/data1.csv",
+                    "--dataset-id",
+                    "dataset-a",
+                    "--outdir",
+                    "outputs",
+                    "--llm",
+                    "test-model",
+                    "--max-concurrency",
+                    "4",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        run_csv.assert_called_once_with(
+            input_path="examples/data1.csv",
+            outdir="outputs",
+            dataset_id="dataset-a",
+            llm="test-model",
+            max_concurrency=4,
+        )
 
 
 class McpServerTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Replace duplicated `mainConcurrent.py` pipeline implementation with a thin CLI adapter around `metamorph.core.run_MetaMorph_on_csv`.
- Preserve both documented invocation styles: `python metamorph/mainConcurrent.py --help` and `python -m metamorph.mainConcurrent --help`.
- Add a CLI delegation test to verify parsed arguments are passed directly to the core runner.

## Verification
- `pixi run python -m unittest discover -s tests -v`
- `pixi run python metamorph/mainConcurrent.py --help`
- `pixi run python -m metamorph.mainConcurrent --help`

## Notes
- `metamorph.core` remains the authoritative implementation for graph construction, CSV execution, report writing, and cleaned dataframe generation.
- Existing untracked local files (`AGENTS.md`, generated logo assets, local reports) were not included.

Closes #30
