### PR TITLE
Add deterministic validation before LLM validation

### DIFF
--- a/metamorph/validation_contracts.py
+++ b/metamorph/validation_contracts.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+
+JSONScalar = str | int | float | bool | None
+
+RECOVERABLE_CATEGORIES = {
+    "empty_output",
+    "invalid_matrix",
+    "row_major_orientation",
+    "row_length_mismatch",
+    "output_name_mismatch",
+    "invalid_scalar",
+    "invalid_confidence",
+}
+
+
+@dataclass(frozen=True)
+class ContractIssue:
+    category: str
+    message: str
+    failed_rows: list[int] = field(default_factory=list)
+    recoverable: bool = True
+
+
+@dataclass(frozen=True)
+class ContractValidationResult:
+    passed: bool
+    issues: list[ContractIssue] = field(default_factory=list)
+
+    @property
+    def failed_rows(self) -> list[int]:
+        rows: set[int] = set()
+        for issue in self.issues:
+            rows.update(issue.failed_rows)
+        return sorted(rows)
+
+    @property
+    def recoverable(self) -> bool:
+        return all(issue.recoverable for issue in self.issues)
+
+    @property
+    def message(self) -> str:
+        return "; ".join(f"{issue.category}: {issue.message}" for issue in self.issues)
+
+
+def is_json_scalar(value: Any) -> bool:
+    if value is None or isinstance(value, (str, bool, int)):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    return False
+
+
+def _dedupe_rows(rows: Iterable[int]) -> list[int]:
+    return sorted({row for row in rows if row >= 0})
+
+
+def validate_transformation_contract(
+    *,
+    raw_values: Sequence[Any],
+    transformed_values: Any,
+    output_names: Sequence[str] | None = None,
+    confidence: Any = None,
+) -> ContractValidationResult:
+    issues: list[ContractIssue] = []
+    expected_rows = len(raw_values)
+
+    if confidence is not None:
+        if not isinstance(confidence, (int, float)) or isinstance(confidence, bool) or not math.isfinite(confidence):
+            issues.append(
+                ContractIssue(
+                    category="invalid_confidence",
+                    message=f"Confidence must be a finite number in [0, 1], got {confidence!r}.",
+                )
+            )
+        elif not 0.0 <= float(confidence) <= 1.0:
+            issues.append(
+                ContractIssue(
+                    category="invalid_confidence",
+                    message=f"Confidence must be in [0, 1], got {confidence!r}.",
+                )
+            )
+
+    if not isinstance(transformed_values, list):
+        return ContractValidationResult(
+            passed=False,
+            issues=[
+                *issues,
+                ContractIssue(
+                    category="invalid_matrix",
+                    message="Transformed values must be a list of output columns.",
+                ),
+            ],
+        )
+
+    if len(transformed_values) == 0:
+        return ContractValidationResult(
+            passed=False,
+            issues=[
+                *issues,
+                ContractIssue(
+                    category="empty_output",
+                    message="Transformed values must include at least one output column.",
+                    failed_rows=list(range(expected_rows)),
+                ),
+            ],
+        )
+
+    expected_output_cols = len(output_names) if output_names is not None else None
+    if (
+        expected_rows > 1
+        and expected_output_cols
+        and len(transformed_values) == expected_rows
+        and expected_output_cols != expected_rows
+        and all(isinstance(row, list) and len(row) == expected_output_cols for row in transformed_values)
+    ):
+        issues.append(
+            ContractIssue(
+                category="row_major_orientation",
+                message=(
+                    "Transformed values look row-major; expected columns-first "
+                    f"shape with {expected_output_cols} output column(s), not {expected_rows} row(s)."
+                ),
+                failed_rows=list(range(expected_rows)),
+            )
+        )
+
+    if output_names is not None and len(output_names) != len(transformed_values):
+        issues.append(
+            ContractIssue(
+                category="output_name_mismatch",
+                message=(
+                    f"Output name count ({len(output_names)}) must match transformed column count "
+                    f"({len(transformed_values)})."
+                ),
+            )
+        )
+
+    for col_idx, column_values in enumerate(transformed_values):
+        if not isinstance(column_values, list):
+            issues.append(
+                ContractIssue(
+                    category="invalid_matrix",
+                    message=f"Output column {col_idx} must be a list, got {type(column_values).__name__}.",
+                )
+            )
+            continue
+
+        if len(column_values) != expected_rows:
+            failed_rows = range(min(len(column_values), expected_rows), max(len(column_values), expected_rows))
+            issues.append(
+                ContractIssue(
+                    category="row_length_mismatch",
+                    message=(
+                        f"Output column {col_idx} has {len(column_values)} row(s); "
+                        f"expected {expected_rows}."
+                    ),
+                    failed_rows=_dedupe_rows(failed_rows),
+                )
+            )
+
+        invalid_rows = [
+            row_idx
+            for row_idx, value in enumerate(column_values[:expected_rows])
+            if not is_json_scalar(value)
+        ]
+        if invalid_rows:
+            issues.append(
+                ContractIssue(
+                    category="invalid_scalar",
+                    message=(
+                        f"Output column {col_idx} contains non-JSON-scalar values "
+                        f"at row(s): {invalid_rows}."
+                    ),
+                    failed_rows=invalid_rows,
+                )
+            )
+
+    return ContractValidationResult(
+        passed=len(issues) == 0,
+        issues=issues,
+    )

--- a/metamorph/validator.py
+++ b/metamorph/validator.py
@@ -9,6 +9,7 @@ from langchain_core.messages import HumanMessage
 from langgraph.graph import START, END, MessagesState
 from langgraph.types import Command
 from utils.MetaMorphState import ValidatorData, MetaMorphState, tracker
+from .validation_contracts import validate_transformation_contract
 
 
 MAX_RETRIES = 5
@@ -65,10 +66,54 @@ async def validator_node(state: MetaMorphState) -> Command:
 
     if refined and getattr(refined, "cleaned_values", None) is not None:
         transformed_values = refined.cleaned_values
+        model_confidence = getattr(refined, "confidence", None)
     elif parsed and getattr(parsed, "parsed_output", None) is not None:
         transformed_values = parsed.parsed_output
+        model_confidence = getattr(parsed, "model_confidence", None)
     else:
         transformed_values = []
+        model_confidence = None
+
+    curr_col = state.input_column_data.column_name if getattr(state, "input_column_data", None) else "unknown_column"
+    output_names = None
+    if parsed and getattr(parsed, "column_name", None):
+        output_names = parsed.column_name.get(curr_col)
+
+    contract_result = validate_transformation_contract(
+        raw_values=(raw.values if raw else []),
+        transformed_values=transformed_values,
+        output_names=output_names,
+        confidence=model_confidence,
+    )
+
+    if not contract_result.passed:
+        decision = "retry" if contract_result.recoverable and retry_count < MAX_RETRIES else "fail"
+        reason = f"Deterministic validation failed: {contract_result.message}"
+        failed_rows = contract_result.failed_rows
+        route = determine_route(decision, retry_count)
+        new_retry_count = retry_count + 1 if decision == "retry" else retry_count
+
+        print(f"Validation: {decision.upper()} — {reason}", flush=True)
+
+        NodeTrackerName = f"validator@{timestamp}"
+        V_PATCH = {
+            "processed_column": [curr_col],
+            "node_path": {curr_col: {NodeTrackerName: reason}},
+            "events_path": [f"ValidatorNode@{timestamp}"],
+        }
+
+        return Command(
+            update={
+                "validator_data": ValidatorData(
+                    passed=False,
+                    failed_rows=failed_rows,
+                    message=reason,
+                    retry_count=new_retry_count,
+                ),
+                "Node_Col_Tracker": V_PATCH,
+            },
+            goto=route,
+        )
 
     messages = [
         {"role": "system", "content": validator_prompt},
@@ -106,10 +151,9 @@ async def validator_node(state: MetaMorphState) -> Command:
     NodeTrackerName = f"validator@{timestamp}"
     
     #Tracker patch (merged by Node_Col_tracker
-    curr_col = state.input_column_data.column_name if getattr(state, "input_column_data", None) else "unknown_column"
     V_PATCH = {
         "processed_column": [curr_col],
-         "node_path": {curr_col: {NodeTrackerName: decision}},
+         "node_path": {curr_col: {NodeTrackerName: reason}},
          "events_path" : [f"ValidatorNode@{timestamp}"]
         # "events_path": [f"Validator → {('Refinement' if decision=='retry' else 'End' if decision=='pass' else 'Supervisor')}"]
      }

--- a/tests/test_prompt_contracts.py
+++ b/tests/test_prompt_contracts.py
@@ -8,7 +8,9 @@ from utils.MetaMorphState import (
     ColSample,
     InputColumnData,
     MetaMorphState,
+    parsedData,
     RefinementResults,
+    ValidatorData,
 )
 from utils.prompts import load_prompts
 
@@ -168,6 +170,53 @@ class StructuredOutputNodeTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(command.update["validator_data"].passed)
         self.assertEqual(command.update["validator_data"].message, "Output is row-aligned and plausible.")
         self.assertEqual(command.update["validator_data"].failed_rows, [])
+
+    async def test_validator_node_retries_contract_failure_without_llm(self):
+        state = MetaMorphState(
+            input_column_data=InputColumnData(column_name="height", values=["5 ft 10 in", "170 cm"]),
+            ColumnSample=ColSample(column_name="height", row_count=2),
+            parsed_data_output=parsedData(column_name={"height": ["height_cm"]}),
+            refinement_results=RefinementResults(
+                cleaned_values=[[177.8], [170.0]],
+                confidence=0.98,
+                refinement_attempts=1,
+            ),
+        )
+
+        with patch.object(validator, "get_llm", side_effect=AssertionError("LLM should not be called")):
+            command = await validator.validator_node(state)
+
+        self.assertEqual(command.goto, "refinement_agent")
+        self.assertFalse(command.update["validator_data"].passed)
+        self.assertEqual(command.update["validator_data"].retry_count, 1)
+        self.assertEqual(command.update["validator_data"].failed_rows, [0, 1])
+        self.assertIn("row_major_orientation", command.update["validator_data"].message)
+
+    async def test_validator_node_routes_exhausted_contract_failure_to_supervisor(self):
+        state = MetaMorphState(
+            input_column_data=InputColumnData(column_name="height", values=["5 ft 10 in", "170 cm"]),
+            ColumnSample=ColSample(column_name="height", row_count=2),
+            parsed_data_output=parsedData(column_name={"height": ["height_cm"]}),
+            refinement_results=RefinementResults(
+                cleaned_values=[[177.8]],
+                confidence=0.98,
+                refinement_attempts=6,
+            ),
+            validator_data=ValidatorData(
+                passed=False,
+                failed_rows=[1],
+                retry_count=validator.MAX_RETRIES,
+                message="Previous retry",
+            ),
+        )
+
+        with patch.object(validator, "get_llm", side_effect=AssertionError("LLM should not be called")):
+            command = await validator.validator_node(state)
+
+        self.assertEqual(command.goto, "supervisor")
+        self.assertFalse(command.update["validator_data"].passed)
+        self.assertEqual(command.update["validator_data"].retry_count, validator.MAX_RETRIES)
+        self.assertIn("row_length_mismatch", command.update["validator_data"].message)
 
 
 if __name__ == "__main__":

--- a/tests/test_validation_contracts.py
+++ b/tests/test_validation_contracts.py
@@ -1,0 +1,88 @@
+import unittest
+
+from metamorph.validation_contracts import validate_transformation_contract
+
+
+class TransformationContractTests(unittest.TestCase):
+    def test_valid_single_output_column(self):
+        result = validate_transformation_contract(
+            raw_values=["5 ft 10 in", "170 cm"],
+            transformed_values=[[177.8, 170.0]],
+            output_names=["height_cm"],
+            confidence=0.99,
+        )
+
+        self.assertTrue(result.passed)
+        self.assertEqual(result.issues, [])
+
+    def test_valid_multi_output_column(self):
+        result = validate_transformation_contract(
+            raw_values=["2024-01-12", "unknown"],
+            transformed_values=[["2024-01-12", None], [2024, None]],
+            output_names=["date_iso", "year"],
+            confidence=0.9,
+        )
+
+        self.assertTrue(result.passed)
+
+    def test_row_major_shape_is_detected(self):
+        result = validate_transformation_contract(
+            raw_values=["5 ft 10 in", "170 cm"],
+            transformed_values=[[177.8], [170.0]],
+            output_names=["height_cm"],
+            confidence=0.9,
+        )
+
+        self.assertFalse(result.passed)
+        self.assertIn("row_major_orientation", [issue.category for issue in result.issues])
+        self.assertEqual(result.failed_rows, [0, 1])
+
+    def test_row_length_mismatch_is_detected(self):
+        result = validate_transformation_contract(
+            raw_values=["a", "b", "c"],
+            transformed_values=[["a", "b"]],
+            output_names=["cleaned"],
+            confidence=0.8,
+        )
+
+        self.assertFalse(result.passed)
+        self.assertIn("row_length_mismatch", [issue.category for issue in result.issues])
+        self.assertEqual(result.failed_rows, [2])
+
+    def test_invalid_scalar_is_detected(self):
+        result = validate_transformation_contract(
+            raw_values=["a", "b"],
+            transformed_values=[["a", {"bad": "value"}]],
+            output_names=["cleaned"],
+            confidence=0.8,
+        )
+
+        self.assertFalse(result.passed)
+        self.assertIn("invalid_scalar", [issue.category for issue in result.issues])
+        self.assertEqual(result.failed_rows, [1])
+
+    def test_output_name_mismatch_is_detected(self):
+        result = validate_transformation_contract(
+            raw_values=["a", "b"],
+            transformed_values=[["a", "b"], [1, 2]],
+            output_names=["cleaned"],
+            confidence=0.8,
+        )
+
+        self.assertFalse(result.passed)
+        self.assertIn("output_name_mismatch", [issue.category for issue in result.issues])
+
+    def test_invalid_confidence_is_detected(self):
+        result = validate_transformation_contract(
+            raw_values=["a"],
+            transformed_values=[["a"]],
+            output_names=["cleaned"],
+            confidence=1.2,
+        )
+
+        self.assertFalse(result.passed)
+        self.assertIn("invalid_confidence", [issue.category for issue in result.issues])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `metamorph.validation_contracts` for deterministic transformation contract checks.
- Validate output matrix shape, row-major orientation, row alignment, JSON scalar values, output-name counts, and confidence range before calling the LLM validator.
- Route recoverable contract failures to refinement without spending an LLM call; route exhausted failures back through the existing supervisor path.
- Preserve clear validation categories and failed row indices in `ValidatorData.message` and `failed_rows`.

## Verification
- `pixi run python -m unittest discover -s tests -v`
- `pixi run python metamorph/mainConcurrent.py --help`
- `pixi run python -m metamorph.mainConcurrent --help`

## Notes
- This PR keeps semantic validation in the existing LLM validator and adds deterministic checks only for contracts Python can verify reliably.
- Existing untracked local files (`AGENTS.md`, generated logo assets, local reports) were not included.

Closes #31
