### PR TITLE
Add graph guardrails and targeted retry feedback

### DIFF
--- a/metamorph/core.py
+++ b/metamorph/core.py
@@ -10,6 +10,7 @@ import os
 import pandas as pd
 from pathlib import Path
 from langgraph.graph import StateGraph
+from langgraph.errors import GraphRecursionError
 import argparse
 
 
@@ -44,6 +45,10 @@ class FinalDataSummary(BaseModel):
     confidence: float
     ColNames: Dict[str, List[str]]
     TransformedValues: List[List[JSONScalar]]
+    retryCount: int = 0
+    validationStatus: Optional[str] = None
+    validationMessage: Optional[str] = None
+    finalRoute: Optional[str] = None
     error: Optional[str] = None
 
 class DatasetSummary(BaseModel):
@@ -73,20 +78,42 @@ async def colRunner(app, dataset_id: str, col_name: str, col_values: list, col_s
         ColumnSample=col_sample,
     )
     thread_id = generate_thread_id(dataset_id)
-    config = {"configurable": {"thread_id": f"{thread_id}:{col_name}"}}
+    config = {
+        "configurable": {"thread_id": f"{thread_id}:{col_name}"},
+        "recursion_limit": 24,
+    }
 
-    FinalState = await app.ainvoke(init, config=config)
+    try:
+        FinalState = await app.ainvoke(init, config=config)
+    except GraphRecursionError as e:
+        return FinalDataSummary(
+            trackerInfo=tracker(),
+            confidence=0.0,
+            ColNames={col_name: []},
+            TransformedValues=[],
+            validationStatus="graph_step_limit",
+            validationMessage=str(e),
+            finalRoute="GraphRecursionError",
+            error=f"GraphRecursionError: {e}",
+        )
 
     try:
 
         ParsedOut = get_key(FinalState, "parsed_data_output")
         Refined = get_key(FinalState, "refinement_results")
         TrackerInfo = get_key(FinalState, "Node_Col_Tracker")
+        ValidatorInfo = get_key(FinalState, "validator_data")
 
 
         ColumnNames = get_attr_or_item(ParsedOut, "column_name")
         TransformedData = get_attr_or_item(Refined, "cleaned_values")
         ModelConfidence = get_attr_or_item(Refined, "confidence", 0.0)
+        retry_count = get_attr_or_item(ValidatorInfo, "retry_count", 0) if ValidatorInfo else 0
+        validation_status = get_attr_or_item(ValidatorInfo, "status", None) if ValidatorInfo else None
+        validation_message = get_attr_or_item(ValidatorInfo, "message", None) if ValidatorInfo else None
+        final_route = get_attr_or_item(ValidatorInfo, "final_route", None) if ValidatorInfo else None
+        validation_passed = get_attr_or_item(ValidatorInfo, "passed", True) if ValidatorInfo else True
+        error_message = None if validation_passed else validation_message
         
         #print(f"ColNames: {ColumnNames}\n")
         ColumnNames 
@@ -96,6 +123,11 @@ async def colRunner(app, dataset_id: str, col_name: str, col_values: list, col_s
             confidence=ModelConfidence,
             ColNames=ColumnNames,
             TransformedValues=TransformedData,
+            retryCount=retry_count,
+            validationStatus=validation_status,
+            validationMessage=validation_message,
+            finalRoute=final_route,
+            error=error_message,
         )
 
     except Exception as e:

--- a/metamorph/imagoScribe.py
+++ b/metamorph/imagoScribe.py
@@ -34,6 +34,12 @@ def summarizeTransformations(Res):
         lines.append(f"---\n## Column: `{col}`")
         lines.append(f"**Confidence:** {data.get('confidence', 0):.2f}")
         lines.append(f"**Status:** {'FAILED' if data.get('error') else 'SUCCESS'}")
+        lines.append(f"**Retries:** {data.get('retryCount', 0)}")
+        lines.append(f"**Validation:** {data.get('validationStatus') or '—'}")
+        if data.get("validationMessage"):
+            lines.append(f"**Validation Message:** {data['validationMessage']}")
+        if data.get("finalRoute"):
+            lines.append(f"**Final Route:** `{data['finalRoute']}`")
         lines.append("\n### Transformation Path")
         events = " → ".join([e.split('@')[0] for e in data['trackerInfo']['events_path']])
         lines.append(f"`{events}`")

--- a/metamorph/refinement.py
+++ b/metamorph/refinement.py
@@ -35,15 +35,27 @@ async def refinement_agent(state: MetaMorphState) -> Command:
     parsed = state.parsed_data_output.parsed_output
     schema = state.schema_inference
     raw = state.input_column_data.values
+    validator_feedback = getattr(state, "validator_data", None)
 
     # Combine all context into one user message
     # Do we ignore passing raw inputs into the refiner again? token management
     #Now that we have the possibility of multiple columns per col do we pass all at once? yes for now as we don't want to pass raw and SI redundantly 
 
+    retry_feedback = ""
+    if validator_feedback and validator_feedback.message:
+        retry_feedback = (
+            "\n\nValidator feedback from the previous attempt:\n"
+            f"- status: {validator_feedback.status}\n"
+            f"- retry_count: {validator_feedback.retry_count}\n"
+            f"- failed_rows: {validator_feedback.failed_rows}\n"
+            f"- message: {validator_feedback.message}"
+        )
+
     user_message = (
         f"Original metadata column: {(raw if raw else {})}\n\n"
         f"Initial parsed values: {(parsed if parsed else {})}\n\n"
         f"Schema inference: {(schema.model_dump() if schema else {})}"
+        f"{retry_feedback}"
         )
 
     messages = [

--- a/metamorph/supervisor.py
+++ b/metamorph/supervisor.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from typing import Annotated, Sequence, List, Literal
 #from langchain_core.messages import HumanMessage, SystemMessage, AIMessage
 #from langgraph.graph import StateGraph, START, END, MessagesState
+from langgraph.graph import END
 from langgraph.types import Command
 from datetime import datetime, timezone
 
@@ -14,11 +15,12 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from utils.llm import get_llm, ainvoke_with_backoff
 from utils.prompts import get_prompt
-from utils.MetaMorphState import MetaMorphState
+from utils.MetaMorphState import MetaMorphState, ValidatorData
 
 #llm = get_llm()
 
 Supervisor_system_prompt = get_prompt("Supervisor_system_prompt")
+MAX_GRAPH_STEPS_PER_COLUMN = 24
 
 
 class Supervisor(BaseModel):
@@ -34,12 +36,41 @@ class Supervisor(BaseModel):
     )
 
 
-async def supervisor_node(state: MetaMorphState) -> Command[Literal["schemaInference", "parser_agent", "refinement_agent", "validator_agent"]]: #update with names used to compile graph!
+async def supervisor_node(state: MetaMorphState) -> Command: #update with names used to compile graph!
 
     timestamp = datetime.now(timezone.utc).isoformat()
 
     #context rotuing 
     events = getattr(getattr(state, "Node_Col_Tracker", None), "events_path", []) or [] # we may not need this fallback as our default factories were specified 
+    curr_col = state.input_column_data.column_name
+
+    if len(events) >= MAX_GRAPH_STEPS_PER_COLUMN:
+        reason = (
+            f"Graph step limit exceeded for column '{curr_col}' "
+            f"({len(events)} >= {MAX_GRAPH_STEPS_PER_COLUMN})."
+        )
+        node_tracker_name = f"SupervisorNode@{timestamp}"
+        return Command(
+            update={
+                "validator_data": ValidatorData(
+                    passed=False,
+                    failed_rows=[],
+                    retry_count=(
+                        state.validator_data.retry_count
+                        if getattr(state, "validator_data", None)
+                        else 0
+                    ),
+                    message=reason,
+                    status="graph_step_limit",
+                    final_route=END,
+                ),
+                "Node_Col_Tracker": {
+                    "node_path": {curr_col: {node_tracker_name: reason}},
+                    "events_path": [f"SupervisorNode@{timestamp}"],
+                },
+            },
+            goto=END,
+        )
 
     if events:
         event_context = "Node visited for this column: " + "->".join(map(str, events)) #is this is enough? might need performance eval and experimentation.
@@ -63,8 +94,6 @@ async def supervisor_node(state: MetaMorphState) -> Command[Literal["schemaInfer
     print(f"--- MetaMorph Transitioning: Supervisor → {goto.upper()} ---", flush=True) #Key for initial validation, and see transitional steps.
 
     print(f"Supervisor Justificaiton: {reason}", flush=True)
-
-    curr_col = state.input_column_data.column_name
 
     NodeTrackerName = f"SupervisorNode@{timestamp}"
 

--- a/metamorph/validator.py
+++ b/metamorph/validator.py
@@ -6,7 +6,7 @@ from typing import Literal, List, Optional
 from utils.llm import get_llm, ainvoke_with_backoff
 from utils.prompts import get_prompt
 from langchain_core.messages import HumanMessage
-from langgraph.graph import START, END, MessagesState
+from langgraph.graph import END
 from langgraph.types import Command
 from utils.MetaMorphState import ValidatorData, MetaMorphState, tracker
 from .validation_contracts import validate_transformation_contract
@@ -46,11 +46,21 @@ class ValidatorLLMOutput(BaseModel):
 def determine_route(decision: str, retry_count: int = 0) -> str:
 
     if decision == "pass":
-        return END #Using this for now; need to update with either end_pass or end_fail for more visibility.
+        return END
     elif decision == "retry" and retry_count < MAX_RETRIES:
         return "refinement_agent"  # name of the retry target
     else:
-        return "supervisor"
+        return END
+
+
+def validation_status(decision: str, retry_count: int = 0, *, model_error: bool = False) -> str:
+    if decision == "pass":
+        return "pass"
+    if model_error:
+        return "model_error" if retry_count >= MAX_RETRIES else "recoverable_retry"
+    if decision == "retry" and retry_count < MAX_RETRIES:
+        return "recoverable_retry"
+    return "terminal_fail"
 
 async def validator_node(state: MetaMorphState) -> Command:
     timestamp = datetime.now(timezone.utc).isoformat()
@@ -91,6 +101,7 @@ async def validator_node(state: MetaMorphState) -> Command:
         reason = f"Deterministic validation failed: {contract_result.message}"
         failed_rows = contract_result.failed_rows
         route = determine_route(decision, retry_count)
+        status = validation_status(decision, retry_count)
         new_retry_count = retry_count + 1 if decision == "retry" else retry_count
 
         print(f"Validation: {decision.upper()} — {reason}", flush=True)
@@ -109,6 +120,8 @@ async def validator_node(state: MetaMorphState) -> Command:
                     failed_rows=failed_rows,
                     message=reason,
                     retry_count=new_retry_count,
+                    status=status,
+                    final_route=route,
                 ),
                 "Node_Col_Tracker": V_PATCH,
             },
@@ -129,6 +142,8 @@ async def validator_node(state: MetaMorphState) -> Command:
     decision, reason, conf, failed_rows = None, None, 0.0, []
     llm = get_llm()
 
+    model_error = False
+
     try:
         #res = await llm.with_structured_output(
          #   ValidatorLLMOutput, method="function_calling"
@@ -140,6 +155,7 @@ async def validator_node(state: MetaMorphState) -> Command:
         decision, reason, conf, failed_rows = res.decision, res.reason, res.confidence, res.failed_rows_indices
     except Exception as e:
         # Fallback behavior on LLM failure: treat as retry (bounded by MAX_RETRIES)
+        model_error = True
         decision = "retry" if retry_count < MAX_RETRIES else "fail"
         reason = f"Validator LLM error: {e}"
         conf = 0.0
@@ -147,6 +163,7 @@ async def validator_node(state: MetaMorphState) -> Command:
     print(f"Validation: {decision.upper()} — {reason}", flush=True)
 
     route = determine_route(decision, retry_count)
+    status = validation_status(decision, retry_count, model_error=model_error)
 
     NodeTrackerName = f"validator@{timestamp}"
     
@@ -168,6 +185,8 @@ async def validator_node(state: MetaMorphState) -> Command:
             failed_rows=failed_rows, #I added in the row level checks.
             message=reason,
             retry_count=new_retry_count,
+            status=status,
+            final_route=route,
         ),
         #"messages": [HumanMessage(content=reason, name="validator")],
         #"validation_confidence": conf,

--- a/tests/test_prompt_contracts.py
+++ b/tests/test_prompt_contracts.py
@@ -11,6 +11,7 @@ from utils.MetaMorphState import (
     parsedData,
     RefinementResults,
     ValidatorData,
+    tracker,
 )
 from utils.prompts import load_prompts
 
@@ -95,6 +96,25 @@ class StructuredOutputNodeTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(command.goto, "schemaInference")
         node_path = command.update["Node_Col_Tracker"]["node_path"]["height"]
         self.assertIn("Schema has not been inferred yet.", node_path.values())
+
+    async def test_supervisor_node_ends_when_graph_step_limit_is_reached(self):
+        state = MetaMorphState(
+            input_column_data=InputColumnData(column_name="height", values=["5 ft 10 in"]),
+            ColumnSample=ColSample(column_name="height", row_count=1),
+            Node_Col_Tracker=tracker(
+                events_path=[
+                    f"Node{i}@2026-05-28T00:00:00+00:00"
+                    for i in range(supervisor.MAX_GRAPH_STEPS_PER_COLUMN)
+                ]
+            ),
+        )
+
+        with patch.object(supervisor, "get_llm", side_effect=AssertionError("LLM should not be called")):
+            command = await supervisor.supervisor_node(state)
+
+        self.assertEqual(command.goto, END)
+        self.assertEqual(command.update["validator_data"].status, "graph_step_limit")
+        self.assertIn("Graph step limit exceeded", command.update["validator_data"].message)
 
     async def test_schema_inference_node_uses_structured_schema_fields(self):
         fake_llm = FakeLLM()
@@ -192,7 +212,7 @@ class StructuredOutputNodeTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(command.update["validator_data"].failed_rows, [0, 1])
         self.assertIn("row_major_orientation", command.update["validator_data"].message)
 
-    async def test_validator_node_routes_exhausted_contract_failure_to_supervisor(self):
+    async def test_validator_node_routes_exhausted_contract_failure_to_end(self):
         state = MetaMorphState(
             input_column_data=InputColumnData(column_name="height", values=["5 ft 10 in", "170 cm"]),
             ColumnSample=ColSample(column_name="height", row_count=2),
@@ -213,9 +233,10 @@ class StructuredOutputNodeTests(unittest.IsolatedAsyncioTestCase):
         with patch.object(validator, "get_llm", side_effect=AssertionError("LLM should not be called")):
             command = await validator.validator_node(state)
 
-        self.assertEqual(command.goto, "supervisor")
+        self.assertEqual(command.goto, "__end__")
         self.assertFalse(command.update["validator_data"].passed)
         self.assertEqual(command.update["validator_data"].retry_count, validator.MAX_RETRIES)
+        self.assertEqual(command.update["validator_data"].status, "terminal_fail")
         self.assertIn("row_length_mismatch", command.update["validator_data"].message)
 
 

--- a/tests/test_validator_flow.py
+++ b/tests/test_validator_flow.py
@@ -1,0 +1,152 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from langgraph.graph import END
+
+from metamorph import validator
+from utils.MetaMorphState import (
+    InputColumnData,
+    MetaMorphState,
+    ColSample,
+    RefinementResults,
+    ValidatorData,
+    parsedData,
+)
+
+
+class FakeLlm:
+    def with_structured_output(self, *args, **kwargs):
+        return self
+
+
+def make_state(
+    *,
+    raw_values=None,
+    transformed_values=None,
+    output_names=None,
+    retry_count=0,
+):
+    raw_values = raw_values if raw_values is not None else ["a", "b"]
+    transformed_values = transformed_values if transformed_values is not None else [["a", "b"]]
+    output_names = output_names if output_names is not None else ["cleaned"]
+
+    state = MetaMorphState(
+        input_column_data=InputColumnData(column_name="sample", values=raw_values),
+        ColumnSample=ColSample(column_name="sample", row_count=len(raw_values)),
+        parsed_data_output=parsedData(
+            column_name={"sample": output_names},
+            parsed_output=transformed_values,
+            model_confidence=0.9,
+        ),
+        refinement_results=RefinementResults(
+            cleaned_values=transformed_values,
+            confidence=0.9,
+            refinement_attempts=1,
+        ),
+    )
+    if retry_count:
+        state.validator_data = ValidatorData(
+            passed=False,
+            failed_rows=[],
+            retry_count=retry_count,
+            message="previous retry",
+            status="recoverable_retry",
+            final_route="refinement_agent",
+        )
+    return state
+
+
+class ValidatorFlowTests(unittest.IsolatedAsyncioTestCase):
+    async def test_validator_pass_ends_graph(self):
+        llm_result = SimpleNamespace(
+            decision="pass",
+            reason="looks valid",
+            confidence=0.95,
+            failed_rows_indices=[],
+        )
+
+        with (
+            patch.object(validator, "get_llm", return_value=FakeLlm()),
+            patch.object(validator, "ainvoke_with_backoff", return_value=llm_result),
+        ):
+            result = await validator.validator_node(make_state())
+
+        self.assertEqual(result.goto, END)
+        validator_data = result.update["validator_data"]
+        self.assertTrue(validator_data.passed)
+        self.assertEqual(validator_data.status, "pass")
+        self.assertEqual(validator_data.retry_count, 0)
+        self.assertEqual(validator_data.final_route, END)
+
+    async def test_validator_retry_then_pass_preserves_retry_count(self):
+        retry_result = await validator.validator_node(
+            make_state(transformed_values=[["a"]])
+        )
+
+        self.assertEqual(retry_result.goto, "refinement_agent")
+        retry_data = retry_result.update["validator_data"]
+        self.assertFalse(retry_data.passed)
+        self.assertEqual(retry_data.status, "recoverable_retry")
+        self.assertEqual(retry_data.retry_count, 1)
+        self.assertEqual(retry_data.failed_rows, [1])
+
+        llm_result = SimpleNamespace(
+            decision="pass",
+            reason="fixed",
+            confidence=0.95,
+            failed_rows_indices=[],
+        )
+        passing_state = make_state(retry_count=retry_data.retry_count)
+
+        with (
+            patch.object(validator, "get_llm", return_value=FakeLlm()),
+            patch.object(validator, "ainvoke_with_backoff", return_value=llm_result),
+        ):
+            pass_result = await validator.validator_node(passing_state)
+
+        pass_data = pass_result.update["validator_data"]
+        self.assertEqual(pass_result.goto, END)
+        self.assertTrue(pass_data.passed)
+        self.assertEqual(pass_data.status, "pass")
+        self.assertEqual(pass_data.retry_count, 1)
+
+    async def test_validator_retry_exhaustion_ends_graph(self):
+        result = await validator.validator_node(
+            make_state(
+                transformed_values=[["a"]],
+                retry_count=validator.MAX_RETRIES,
+            )
+        )
+
+        self.assertEqual(result.goto, END)
+        validator_data = result.update["validator_data"]
+        self.assertFalse(validator_data.passed)
+        self.assertEqual(validator_data.status, "terminal_fail")
+        self.assertEqual(validator_data.retry_count, validator.MAX_RETRIES)
+        self.assertEqual(validator_data.final_route, END)
+
+    async def test_validator_terminal_fail_ends_graph(self):
+        llm_result = SimpleNamespace(
+            decision="fail",
+            reason="semantic mismatch",
+            confidence=0.8,
+            failed_rows_indices=[0],
+        )
+
+        with (
+            patch.object(validator, "get_llm", return_value=FakeLlm()),
+            patch.object(validator, "ainvoke_with_backoff", return_value=llm_result),
+        ):
+            result = await validator.validator_node(make_state())
+
+        self.assertEqual(result.goto, END)
+        validator_data = result.update["validator_data"]
+        self.assertFalse(validator_data.passed)
+        self.assertEqual(validator_data.status, "terminal_fail")
+        self.assertEqual(validator_data.message, "semantic mismatch")
+        self.assertEqual(validator_data.failed_rows, [0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/MetaMorphState.py
+++ b/utils/MetaMorphState.py
@@ -43,6 +43,8 @@ class ValidatorData(BaseModel):
     failed_rows: List[int]
     retry_count: int = 0
     message: Optional[str] = None
+    status: str = "pending"
+    final_route: Optional[str] = None
 
 class ColSample(BaseModel):
     column_name: str = Field(default_factory=str)
@@ -104,4 +106,3 @@ class MetaMorphState(BaseModel):
     validator_data: Optional[ValidatorData] = None
     Node_Col_Tracker: Annotated[tracker, merge_tracker] = Field(default_factory=tracker)
     #ImagoContext: ImagoState = Field(default_factory=ImagoState)
-

--- a/utils/ScribeTemplate.py
+++ b/utils/ScribeTemplate.py
@@ -447,7 +447,17 @@ html_template = Template(r"""
           <div><b>confidence</b>={{ "%.2f"|format(conf) }}</div>
           <div><b>shape</b>={{ n_rows }}×{{ n_cols }}</div>
           <div><b>mapped_cols</b>={{ names|length }}</div>
+          <div><b>retries</b>={{ d.retryCount or 0 }}</div>
+          <div><b>validation</b>={{ d.validationStatus or "—" }}</div>
+          <div><b>final_route</b>={{ d.finalRoute or "—" }}</div>
         </div>
+
+        {% if d.validationMessage %}
+          <div class="row">
+            <div class="muted small"><b>Validation message</b></div>
+            <div class="code">{{ d.validationMessage }}</div>
+          </div>
+        {% endif %}
 
         <div class="row">
           <div class="muted small"><b>🧵 Agents</b></div>


### PR DESCRIPTION
## Summary
- add bounded graph execution via supervisor step cap and LangGraph recursion limit handling
- route terminal validation failures to END with explicit validation status/final route metadata
- feed validator messages and failed row indices into subsequent refinement attempts
- surface retry count, validation status/message, and final route in Markdown and HTML reports
- add deterministic tests for pass, retry-then-pass, retry exhaustion, terminal failure, and graph step cap

## Verification
- pixi run python -m unittest discover -s tests
- pixi run python metamorph/mainConcurrent.py --help

Closes #32