### PR TITLE
Add RunConfig manifest and run metrics

### DIFF
--- a/metamorph/core.py
+++ b/metamorph/core.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Dict, List, Union, Optional
-from pydantic import BaseModel
+from typing import Any, Dict, List, Union, Optional
+from pydantic import BaseModel, Field
 import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import sys
-import os
+import json
+import logging
 import pandas as pd
 from pathlib import Path
 from langgraph.graph import StateGraph
@@ -39,6 +40,24 @@ from .input import build_sample_data
 
 JSONScalar = Union[str, int, float, bool, None]
 DEFAULT_OUTDIR = "Reports"
+DEFAULT_GRAPH_RECURSION_LIMIT = 24
+RUN_MANIFEST_FILENAME = "run.json"
+
+logger = logging.getLogger(__name__)
+
+class RunConfig(BaseModel):
+    provider: str = "openai"
+    requested_model: str
+    resolved_model: str
+    max_concurrency: int = 2
+    graph_recursion_limit: int = DEFAULT_GRAPH_RECURSION_LIMIT
+    output_dir: str
+    write_markdown_report: bool = True
+    write_html_report: bool = True
+    write_cleaned_csv: bool = True
+    write_run_manifest: bool = True
+    sample_strategy: str = "head_tail_random_unique_preview"
+    debug: bool = False
 
 class FinalDataSummary(BaseModel):
     trackerInfo: tracker
@@ -55,9 +74,52 @@ class DatasetSummary(BaseModel):
     dataset_id: str
     started_at: str
     finished_at: str
+    duration_seconds: float = 0.0
     n_success: int
     n_failed: int
+    total_retry_count: int = 0
+    validation_status_counts: Dict[str, int] = Field(default_factory=dict)
     colData: Dict[str, FinalDataSummary]
+
+class RunOutputFiles(BaseModel):
+    cleaned_csv: str
+    report_md: str
+    report_html: str
+    run_manifest: str
+
+class NodeTiming(BaseModel):
+    node: str
+    timestamp: Optional[str] = None
+    duration_to_next_seconds: Optional[float] = None
+
+class ColumnRunSummary(BaseModel):
+    status: str
+    validation_status: Optional[str] = None
+    validation_message: Optional[str] = None
+    retry_count: int = 0
+    final_route: Optional[str] = None
+    confidence: float = 0.0
+    output_columns: List[str] = Field(default_factory=list)
+    output_shape: Dict[str, int] = Field(default_factory=dict)
+    node_count: int = 0
+    node_timings: List[NodeTiming] = Field(default_factory=list)
+    model_name: Optional[str] = None
+    estimated_tokens: Optional[int] = None
+    estimated_cost_usd: Optional[float] = None
+    error: Optional[str] = None
+
+class RunManifest(BaseModel):
+    schema_version: str = "1.0"
+    dataset_id: str
+    input_path: str
+    started_at: str
+    finished_at: str
+    duration_seconds: float
+    model: str
+    config: RunConfig
+    outputs: RunOutputFiles
+    summary: Dict[str, Any]
+    columns: Dict[str, ColumnRunSummary]
 
 @dataclass
 class MetaMorphResults:
@@ -67,10 +129,121 @@ class MetaMorphResults:
     report_md_path: str
     report_html_path: str
     cleaned_csv_path: str
+    run_manifest_path: str
     report_md_preview: str
 
 
-async def colRunner(app, dataset_id: str, col_name: str, col_values: list, col_sample):
+def _parse_event(event: str) -> tuple[str, Optional[str]]:
+    node, sep, ts = event.partition("@")
+    return node, ts if sep and ts else None
+
+
+def _parse_iso_seconds(ts: Optional[str]) -> Optional[datetime]:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _node_timings(events: List[str]) -> List[NodeTiming]:
+    parsed = [_parse_event(event) for event in events]
+    timings: List[NodeTiming] = []
+    for idx, (node, ts) in enumerate(parsed):
+        current_ts = _parse_iso_seconds(ts)
+        next_ts = _parse_iso_seconds(parsed[idx + 1][1]) if idx + 1 < len(parsed) else None
+        duration = None
+        if current_ts and next_ts:
+            duration = max((next_ts - current_ts).total_seconds(), 0.0)
+        timings.append(
+            NodeTiming(
+                node=node,
+                timestamp=ts,
+                duration_to_next_seconds=duration,
+            )
+        )
+    return timings
+
+
+def _duration_seconds(started_at: str, finished_at: str) -> float:
+    start = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+    finish = datetime.fromisoformat(finished_at.replace("Z", "+00:00"))
+    return max((finish - start).total_seconds(), 0.0)
+
+
+def _column_output_shape(summary: FinalDataSummary) -> Dict[str, int]:
+    values = summary.TransformedValues or []
+    return {
+        "rows": len(values[0]) if values and isinstance(values[0], list) else 0,
+        "columns": len(values),
+    }
+
+
+def _build_column_manifest(col: str, summary: FinalDataSummary, model_name: str) -> ColumnRunSummary:
+    events = summary.trackerInfo.events_path if summary.trackerInfo else []
+    output_columns = summary.ColNames.get(col, []) if summary.ColNames else []
+    return ColumnRunSummary(
+        status="failed" if summary.error else "success",
+        validation_status=summary.validationStatus,
+        validation_message=summary.validationMessage,
+        retry_count=summary.retryCount,
+        final_route=summary.finalRoute,
+        confidence=summary.confidence,
+        output_columns=output_columns,
+        output_shape=_column_output_shape(summary),
+        node_count=len(events),
+        node_timings=_node_timings(events),
+        model_name=model_name,
+        error=summary.error,
+    )
+
+
+def build_run_manifest(
+    *,
+    input_path: Path,
+    cleaned_data: DatasetSummary,
+    model_name: str,
+    config: RunConfig,
+    output_files: RunOutputFiles,
+) -> RunManifest:
+    return RunManifest(
+        dataset_id=cleaned_data.dataset_id,
+        input_path=str(input_path),
+        started_at=cleaned_data.started_at,
+        finished_at=cleaned_data.finished_at,
+        duration_seconds=cleaned_data.duration_seconds,
+        model=model_name,
+        config=config,
+        outputs=output_files,
+        summary={
+            "n_success": cleaned_data.n_success,
+            "n_failed": cleaned_data.n_failed,
+            "n_columns": len(cleaned_data.colData),
+            "total_retry_count": cleaned_data.total_retry_count,
+            "validation_status_counts": cleaned_data.validation_status_counts,
+        },
+        columns={
+            col: _build_column_manifest(col, summary, model_name)
+            for col, summary in cleaned_data.colData.items()
+        },
+    )
+
+
+async def colRunner(
+    app,
+    dataset_id: str,
+    col_name: str,
+    col_values: list,
+    col_sample,
+    graph_recursion_limit: int = DEFAULT_GRAPH_RECURSION_LIMIT,
+):
+    logger.info(
+        "Starting column run dataset_id=%s column_name=%s",
+        dataset_id,
+        col_name,
+        extra={"dataset_id": dataset_id, "column_name": col_name},
+    )
     init = MetaMorphState(
         input_column_data=InputColumnData(
             column_name=col_name,
@@ -80,12 +253,18 @@ async def colRunner(app, dataset_id: str, col_name: str, col_values: list, col_s
     thread_id = generate_thread_id(dataset_id)
     config = {
         "configurable": {"thread_id": f"{thread_id}:{col_name}"},
-        "recursion_limit": 24,
+        "recursion_limit": graph_recursion_limit,
     }
 
     try:
         FinalState = await app.ainvoke(init, config=config)
     except GraphRecursionError as e:
+        logger.warning(
+            "Column run hit graph recursion limit dataset_id=%s column_name=%s",
+            dataset_id,
+            col_name,
+            extra={"dataset_id": dataset_id, "column_name": col_name},
+        )
         return FinalDataSummary(
             trackerInfo=tracker(),
             confidence=0.0,
@@ -118,7 +297,7 @@ async def colRunner(app, dataset_id: str, col_name: str, col_values: list, col_s
         #print(f"ColNames: {ColumnNames}\n")
         ColumnNames 
 
-        return FinalDataSummary(
+        summary = FinalDataSummary(
             trackerInfo=TrackerInfo,
             confidence=ModelConfidence,
             ColNames=ColumnNames,
@@ -129,8 +308,28 @@ async def colRunner(app, dataset_id: str, col_name: str, col_values: list, col_s
             finalRoute=final_route,
             error=error_message,
         )
+        logger.info(
+            "Finished column run dataset_id=%s column_name=%s validation_status=%s retry_count=%s",
+            dataset_id,
+            col_name,
+            summary.validationStatus,
+            summary.retryCount,
+            extra={
+                "dataset_id": dataset_id,
+                "column_name": col_name,
+                "validation_status": summary.validationStatus,
+                "retry_count": summary.retryCount,
+            },
+        )
+        return summary
 
     except Exception as e:
+        logger.exception(
+            "Column run summary extraction failed dataset_id=%s column_name=%s",
+            dataset_id,
+            col_name,
+            extra={"dataset_id": dataset_id, "column_name": col_name},
+        )
         return FinalDataSummary(
             trackerInfo=tracker(),
             confidence=0.0,
@@ -139,7 +338,13 @@ async def colRunner(app, dataset_id: str, col_name: str, col_values: list, col_s
             error=f"{type(e).__name__}: {e}",
         )
     
-async def run_all(graph, dataset_id: str, columns: Dict[str, list], max_concurrency=5) -> DatasetSummary:
+async def run_all(
+    graph,
+    dataset_id: str,
+    columns: Dict[str, list],
+    max_concurrency=5,
+    graph_recursion_limit: int = DEFAULT_GRAPH_RECURSION_LIMIT,
+) -> DatasetSummary:
 
     #cp = AsyncSqliteSaver.from_conn_string("metamorph.db")
 
@@ -158,7 +363,14 @@ async def run_all(graph, dataset_id: str, columns: Dict[str, list], max_concurre
             col_sample = build_sample_data(series_data)
 
             try:
-                summary = await colRunner(app, dataset_id, col, val, col_sample)
+                summary = await colRunner(
+                    app,
+                    dataset_id,
+                    col,
+                    val,
+                    col_sample,
+                    graph_recursion_limit=graph_recursion_limit,
+                )
                 return col, summary
             except Exception as e:
                 return col, e
@@ -168,6 +380,8 @@ async def run_all(graph, dataset_id: str, columns: Dict[str, list], max_concurre
     col_summaries: Dict[str, FinalDataSummary] = {}
     n_success = 0
     n_failed = 0
+    total_retry_count = 0
+    validation_status_counts: Dict[str, int] = {}
 
     for col, out in results:
         if isinstance(out, Exception):
@@ -183,19 +397,26 @@ async def run_all(graph, dataset_id: str, columns: Dict[str, list], max_concurre
     
         summary = out
         col_summaries[col] = summary
+        total_retry_count += summary.retryCount
+        validation_key = summary.validationStatus or "unknown"
+        validation_status_counts[validation_key] = validation_status_counts.get(validation_key, 0) + 1
         if summary.error:
             n_failed += 1
         else:
             n_success += 1
 
     EndTime = datetime.now(timezone.utc).isoformat()
+    duration = _duration_seconds(StartTime, EndTime)
 
     return DatasetSummary(
         dataset_id=dataset_id,
         started_at=StartTime,
         finished_at=EndTime,
+        duration_seconds=duration,
         n_success=n_success,
         n_failed=n_failed,
+        total_retry_count=total_retry_count,
+        validation_status_counts=validation_status_counts,
         colData=col_summaries,
     )
 
@@ -254,6 +475,7 @@ def run_MetaMorph_on_csv(
     dataset_id: str | None = None,
     llm: str = "gpt-5-nano",
     max_concurrency: int = 2,    
+    debug: bool = False,
 ) -> MetaMorphResults:
     
     input_path = Path(input_path).resolve()
@@ -266,7 +488,20 @@ def run_MetaMorph_on_csv(
 
     set_llm_model(llm)
     model_name = get_llm().model_name
-    print("Using model:", model_name)
+    config = RunConfig(
+        requested_model=llm,
+        resolved_model=model_name,
+        max_concurrency=max_concurrency,
+        graph_recursion_limit=DEFAULT_GRAPH_RECURSION_LIMIT,
+        output_dir=str(outdir),
+        debug=debug,
+    )
+    logger.info(
+        "Starting MetaMorph run dataset_id=%s model=%s",
+        dataset_id or input_path.stem,
+        model_name,
+        extra={"dataset_id": dataset_id or input_path.stem, "model": model_name},
+    )
 
     graph = StateGraph(MetaMorphState)
 
@@ -292,6 +527,7 @@ def run_MetaMorph_on_csv(
             dataset_id=dataset_id,
             columns=columns,
             max_concurrency=max_concurrency,
+            graph_recursion_limit=config.graph_recursion_limit,
         )
     )
 
@@ -300,6 +536,7 @@ def run_MetaMorph_on_csv(
     report_md_path = outdir / f"MetaMorph_Report_{stamp}.md"
     report_html_path = outdir / f"MetaMorph_Report_{stamp}.html"
     cleaned_csv_path = outdir / f"MetaMorph_Cleaned_{stamp}.csv"
+    run_manifest_path = outdir / RUN_MANIFEST_FILENAME
 
     report_md_path.write_text(report_md, encoding="utf-8")
 
@@ -309,6 +546,35 @@ def run_MetaMorph_on_csv(
     cleaned_df = BuildFinalDf(df, cleaned_data)
     cleaned_df.to_csv(cleaned_csv_path, index=False)
 
+    output_files = RunOutputFiles(
+        cleaned_csv=str(cleaned_csv_path),
+        report_md=str(report_md_path),
+        report_html=str(report_html_path),
+        run_manifest=str(run_manifest_path),
+    )
+    run_manifest = build_run_manifest(
+        input_path=input_path,
+        cleaned_data=cleaned_data,
+        model_name=model_name,
+        config=config,
+        output_files=output_files,
+    )
+    run_manifest_path.write_text(
+        json.dumps(run_manifest.model_dump(mode="json"), indent=2),
+        encoding="utf-8",
+    )
+    logger.info(
+        "Finished MetaMorph run dataset_id=%s model=%s run_manifest=%s",
+        dataset_id,
+        model_name,
+        run_manifest_path,
+        extra={
+            "dataset_id": dataset_id,
+            "model": model_name,
+            "run_manifest": str(run_manifest_path),
+        },
+    )
+
     return MetaMorphResults(
         dataset_id=dataset_id,
         model=model_name,
@@ -316,6 +582,7 @@ def run_MetaMorph_on_csv(
         report_md_path=str(report_md_path),
         report_html_path=str(report_html_path),
         cleaned_csv_path=str(cleaned_csv_path),
+        run_manifest_path=str(run_manifest_path),
         report_md_preview=report_md[:1200],
     )
 

--- a/metamorph/imagoScribe.py
+++ b/metamorph/imagoScribe.py
@@ -23,11 +23,18 @@ def summarizeTransformations(Res):
 
     StartTime, EndTime = Res['started_at'], Res['finished_at']
 
-    dur = (parse_iso(EndTime) - parse_iso(StartTime)).total_seconds()
+    dur = Res.get("duration_seconds")
+    if dur is None:
+        dur = (parse_iso(EndTime) - parse_iso(StartTime)).total_seconds()
 
     lines.append(f"**Started:** {StartTime}  \n**Finished:** {EndTime}  \n**Duration:** {dur:.2f}s  \n")
 
     lines.append(f"✅ Success: {Res['n_success']} | ❌ Failed: {Res['n_failed']}\n")
+    lines.append(f"**Total retries:** {Res.get('total_retry_count', 0)}")
+    status_counts = Res.get("validation_status_counts", {})
+    if status_counts:
+        status_summary = ", ".join(f"{k}: {v}" for k, v in sorted(status_counts.items()))
+        lines.append(f"**Validation statuses:** {status_summary}\n")
 
 
     for col, data in Res['colData'].items():

--- a/metamorph/mcp_server.py
+++ b/metamorph/mcp_server.py
@@ -31,6 +31,7 @@ def metamorph_run(
             "cleaned_csv": res.cleaned_csv_path,
             "report_md": res.report_md_path,
             "report_html": res.report_html_path,
+            "run_manifest": res.run_manifest_path,
         },
         "report_md_preview": res.report_md_preview,
     }

--- a/tests/test_core_runner.py
+++ b/tests/test_core_runner.py
@@ -1,4 +1,5 @@
 import os
+import json
 import subprocess
 import sys
 import tempfile
@@ -24,16 +25,20 @@ class CoreRunnerTests(unittest.TestCase):
 
             captured = {}
 
-            async def fake_run_all(graph, dataset_id, columns, max_concurrency):
+            async def fake_run_all(graph, dataset_id, columns, max_concurrency, graph_recursion_limit):
                 captured["dataset_id"] = dataset_id
                 captured["columns"] = columns
                 captured["max_concurrency"] = max_concurrency
+                captured["graph_recursion_limit"] = graph_recursion_limit
                 return core.DatasetSummary(
                     dataset_id=dataset_id,
                     started_at="2026-05-27T00:00:00+00:00",
                     finished_at="2026-05-27T00:00:01+00:00",
+                    duration_seconds=1.0,
                     n_success=1,
                     n_failed=0,
+                    total_retry_count=0,
+                    validation_status_counts={"pass": 1},
                     colData={
                         "height": core.FinalDataSummary(
                             trackerInfo=tracker(),
@@ -66,9 +71,11 @@ class CoreRunnerTests(unittest.TestCase):
             self.assertEqual(captured["dataset_id"], "sample_metadata")
             self.assertEqual(captured["columns"], {"height": ["5 ft 10 in", "170 cm"]})
             self.assertEqual(captured["max_concurrency"], 7)
+            self.assertEqual(captured["graph_recursion_limit"], core.DEFAULT_GRAPH_RECURSION_LIMIT)
             self.assertTrue(Path(result.cleaned_csv_path).exists())
             self.assertTrue(Path(result.report_md_path).exists())
             self.assertTrue(Path(result.report_html_path).exists())
+            self.assertTrue(Path(result.run_manifest_path).exists())
             self.assertEqual(Path(result.cleaned_csv_path).parent.name, core.DEFAULT_OUTDIR)
 
     def test_runner_honors_explicit_dataset_id_and_outdir(self):
@@ -78,11 +85,12 @@ class CoreRunnerTests(unittest.TestCase):
             outdir = tmp_path / "custom_outputs"
             pd.DataFrame({"age": ["10", "11"]}).to_csv(input_path, index=False)
 
-            async def fake_run_all(graph, dataset_id, columns, max_concurrency):
+            async def fake_run_all(graph, dataset_id, columns, max_concurrency, graph_recursion_limit):
                 return core.DatasetSummary(
                     dataset_id=dataset_id,
                     started_at="2026-05-27T00:00:00+00:00",
                     finished_at="2026-05-27T00:00:01+00:00",
+                    duration_seconds=1.0,
                     n_success=1,
                     n_failed=0,
                     colData={
@@ -109,6 +117,67 @@ class CoreRunnerTests(unittest.TestCase):
             self.assertEqual(result.dataset_id, "explicit-dataset")
             self.assertEqual(Path(result.cleaned_csv_path).parent, outdir.resolve())
             self.assertTrue(outdir.exists())
+
+    def test_runner_writes_run_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            input_path = tmp_path / "input.csv"
+            outdir = tmp_path / "outputs"
+            pd.DataFrame({"age": ["10", "11"]}).to_csv(input_path, index=False)
+
+            async def fake_run_all(graph, dataset_id, columns, max_concurrency, graph_recursion_limit):
+                return core.DatasetSummary(
+                    dataset_id=dataset_id,
+                    started_at="2026-05-27T00:00:00+00:00",
+                    finished_at="2026-05-27T00:00:02+00:00",
+                    duration_seconds=2.0,
+                    n_success=1,
+                    n_failed=0,
+                    total_retry_count=1,
+                    validation_status_counts={"pass": 1},
+                    colData={
+                        "age": core.FinalDataSummary(
+                            trackerInfo=tracker(events_path=["ValidatorNode@2026-05-27T00:00:01+00:00"]),
+                            confidence=0.88,
+                            ColNames={"age": ["age_years"]},
+                            TransformedValues=[[10, 11]],
+                            retryCount=1,
+                            validationStatus="pass",
+                            validationMessage="Output is row-aligned.",
+                            finalRoute="__end__",
+                        )
+                    },
+                )
+
+            with (
+                patch.object(core, "set_llm_model"),
+                patch.object(core, "get_llm", return_value=SimpleNamespace(model_name="fake-model")),
+                patch.object(core, "run_all", side_effect=fake_run_all),
+            ):
+                result = core.run_MetaMorph_on_csv(
+                    input_path=input_path,
+                    outdir=outdir,
+                    dataset_id="dataset-a",
+                    llm="test-model",
+                    max_concurrency=3,
+                )
+
+            manifest_path = Path(result.run_manifest_path)
+            self.assertEqual(manifest_path.name, core.RUN_MANIFEST_FILENAME)
+            self.assertTrue(manifest_path.exists())
+
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(manifest["dataset_id"], "dataset-a")
+            self.assertEqual(manifest["input_path"], str(input_path.resolve()))
+            self.assertEqual(manifest["model"], "fake-model")
+            self.assertEqual(manifest["config"]["requested_model"], "test-model")
+            self.assertEqual(manifest["config"]["resolved_model"], "fake-model")
+            self.assertEqual(manifest["config"]["max_concurrency"], 3)
+            self.assertEqual(manifest["summary"]["total_retry_count"], 1)
+            self.assertEqual(manifest["columns"]["age"]["validation_status"], "pass")
+            self.assertEqual(manifest["columns"]["age"]["retry_count"], 1)
+            self.assertEqual(manifest["columns"]["age"]["output_shape"], {"rows": 2, "columns": 1})
+            self.assertIn("run_manifest", manifest["outputs"])
 
 
 class CliTests(unittest.TestCase):
@@ -162,6 +231,7 @@ class McpServerTests(unittest.TestCase):
             cleaned_csv_path="/tmp/cleaned.csv",
             report_md_path="/tmp/report.md",
             report_html_path="/tmp/report.html",
+            run_manifest_path="/tmp/run.json",
             report_md_preview="preview",
         )
 
@@ -186,6 +256,7 @@ class McpServerTests(unittest.TestCase):
         self.assertEqual(result["outputs"]["cleaned_csv"], "/tmp/cleaned.csv")
         self.assertEqual(result["outputs"]["report_md"], "/tmp/report.md")
         self.assertEqual(result["outputs"]["report_html"], "/tmp/report.html")
+        self.assertEqual(result["outputs"]["run_manifest"], "/tmp/run.json")
 
 
 if __name__ == "__main__":

--- a/utils/ScribeTemplate.py
+++ b/utils/ScribeTemplate.py
@@ -415,12 +415,25 @@ html_template = Template(r"""
           <div class="label">⚠️ Failed</div>
           <div class="value">{{ n_failed }}</div>
         </div>
+        <div class="kpi">
+          <div class="label">⏱ Duration</div>
+          <div class="value">{{ "%.2f"|format(duration_seconds or 0) }}s</div>
+        </div>
+        <div class="kpi">
+          <div class="label">🔁 Retries</div>
+          <div class="value">{{ total_retry_count or 0 }}</div>
+        </div>
       </div>
 
       <div class="chips">
         <span class="chip"><span class="dot good"></span>✅ SUCCESS</span>
         <span class="chip"><span class="dot bad"></span>❌ FAILED</span>
         <span class="chip">🧬 columns={{ colData|length }}</span>
+        {% if validation_status_counts %}
+          {% for status, count in validation_status_counts.items() %}
+            <span class="chip">{{ status }}={{ count }}</span>
+          {% endfor %}
+        {% endif %}
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add RunConfig, RunManifest, output file, column summary, and node timing models
- write a machine-readable run.json next to generated reports and cleaned CSV outputs
- include config, input path, model, timestamps, output paths, summary counts, retry metrics, validation status counts, and per-column statuses
- expose run duration/retry/status metrics in Markdown and HTML reports
- return the manifest path from MCP output

## Verification
- pixi run python -m unittest discover -s tests
- pixi run python metamorph/mainConcurrent.py --help

Closes #34