### PR TITLE
Add provider abstraction and per-node model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,31 @@ pixi run python metamorph/mainConcurrent.py --input examples/data1.csv -d testRo
 - --input : path to your dataset (CSV)
 - -d / --dataset-id : identifier used in outputs and reporting
 - -o / --outdir : output directory (created if missing)
-- -l / --llm : model selection (e.g., gpt-5-mini). Currently GPT moels only
+- --provider : LLM provider (`openai` or `groq`). Defaults to `openai`.
+- -l / --llm : default model selection (e.g., `gpt-5-mini` for OpenAI or a Groq chat model)
+- --node-model : optional per-node model override in `NODE=MODEL` form. Can be repeated.
+
+Supported node override keys:
+- `supervisor`
+- `schemaInference`
+- `parser_agent`
+- `refinement_agent`
+- `validator_agent`
+
+Example using Groq as the default provider and a stronger parser model:
+```bash
+pixi run python metamorph/mainConcurrent.py \
+  --input examples/data1.csv \
+  --provider groq \
+  --llm llama-3.1-8b-instant \
+  --node-model parser_agent=llama-3.3-70b-versatile
+```
+
+### Provider credentials
+- OpenAI requires `OPENAI_API_KEY`.
+- Groq requires `GROQ_API_KEY`.
+
+Environment variables are loaded from `.env` via `python-dotenv`.
 
 ## MCP (Model Context Protocol) Support
 
@@ -141,12 +165,15 @@ Runs the full MetaMorph transformation pipeline on a CSV dataset.
 - `input_path` — path to CSV file  
 - `outdir` — output directory  
 - `dataset_id` (optional)  
+- `provider` (optional, `openai` or `groq`)
 - `llm` (optional)  
+- `node_models` (optional mapping of graph node names to model names)
 - `max_concurrency` (optional)  
 
 **Outputs**
 - path to cleaned CSV  
 - Markdown + HTML transformation reports  
+- machine-readable run manifest (`run.json`)
 - short report preview for client inspection  
 
 ### `metamorph_info`
@@ -167,6 +194,7 @@ MetaMorph can generate:
 - per-column summaries (confidence, errors, notes)
 - provenance tracking (events_path, node_path)
 - optional HTML report for debugging and review
+- `run.json` manifest for audit/reproducibility metadata
 
 
 ---

--- a/metamorph/core.py
+++ b/metamorph/core.py
@@ -28,7 +28,7 @@ from .validator import validator_node
 from .imagoScribe import summarizeTransformations
 
 
-from utils.llm import set_llm_model, get_llm
+from utils.llm import LLMClientProvider, LLMProviderConfig, use_llm_provider
 from utils.thread import generate_thread_id
 from utils.MetaMorphState import tracker, MetaMorphState, InputColumnData
 from utils.tools import get_key, get_attr_or_item
@@ -42,13 +42,38 @@ JSONScalar = Union[str, int, float, bool, None]
 DEFAULT_OUTDIR = "Reports"
 DEFAULT_GRAPH_RECURSION_LIMIT = 24
 RUN_MANIFEST_FILENAME = "run.json"
+SUPPORTED_NODE_MODEL_KEYS = {
+    "supervisor",
+    "schemaInference",
+    "parser_agent",
+    "refinement_agent",
+    "validator_agent",
+}
 
 logger = logging.getLogger(__name__)
+
+
+def parse_node_model_overrides(overrides: List[str] | None) -> Dict[str, str]:
+    node_models: Dict[str, str] = {}
+    for override in overrides or []:
+        if "=" not in override:
+            raise ValueError(f"Node model override must use NODE=MODEL format: {override!r}")
+        node, model = override.split("=", 1)
+        node = node.strip()
+        model = model.strip()
+        if not node or not model:
+            raise ValueError(f"Node model override must include both node and model: {override!r}")
+        if node not in SUPPORTED_NODE_MODEL_KEYS:
+            supported = ", ".join(sorted(SUPPORTED_NODE_MODEL_KEYS))
+            raise ValueError(f"Unsupported node override '{node}'. Supported nodes: {supported}.")
+        node_models[node] = model
+    return node_models
 
 class RunConfig(BaseModel):
     provider: str = "openai"
     requested_model: str
     resolved_model: str
+    node_models: Dict[str, str] = Field(default_factory=dict)
     max_concurrency: int = 2
     graph_recursion_limit: int = DEFAULT_GRAPH_RECURSION_LIMIT
     output_dir: str
@@ -473,7 +498,9 @@ def run_MetaMorph_on_csv(
     input_path: str,
     outdir: str | Path = DEFAULT_OUTDIR,
     dataset_id: str | None = None,
+    provider: str = "openai",
     llm: str = "gpt-5-nano",
+    node_models: Dict[str, str] | None = None,
     max_concurrency: int = 2,    
     debug: bool = False,
 ) -> MetaMorphResults:
@@ -485,12 +512,19 @@ def run_MetaMorph_on_csv(
     outdir = Path(outdir).resolve()
     outdir.mkdir(parents=True, exist_ok=True)
 
-
-    set_llm_model(llm)
-    model_name = get_llm().model_name
+    llm_provider = LLMClientProvider(
+        LLMProviderConfig(
+            provider=provider,
+            default_model=llm,
+            node_models=node_models or {},
+        )
+    )
+    model_name = llm_provider.default_model
     config = RunConfig(
+        provider=llm_provider.provider,
         requested_model=llm,
         resolved_model=model_name,
+        node_models=dict(node_models or {}),
         max_concurrency=max_concurrency,
         graph_recursion_limit=DEFAULT_GRAPH_RECURSION_LIMIT,
         output_dir=str(outdir),
@@ -521,15 +555,16 @@ def run_MetaMorph_on_csv(
     stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
 
     # Running METAMORPH on all columns 
-    cleaned_data = asyncio.run(
-        run_all(
-            graph=graph,
-            dataset_id=dataset_id,
-            columns=columns,
-            max_concurrency=max_concurrency,
-            graph_recursion_limit=config.graph_recursion_limit,
+    with use_llm_provider(llm_provider):
+        cleaned_data = asyncio.run(
+            run_all(
+                graph=graph,
+                dataset_id=dataset_id,
+                columns=columns,
+                max_concurrency=max_concurrency,
+                graph_recursion_limit=config.graph_recursion_limit,
+            )
         )
-    )
 
     report_md = summarizeTransformations(cleaned_data.model_dump())
 
@@ -613,10 +648,26 @@ if __name__ == "__main__":
         help=f"Output directory for the generated report files. Defaults to {DEFAULT_OUTDIR}/."
     )
     parser.add_argument(
+        "--provider",
+        default="openai",
+        choices=["openai", "groq"],
+        help="LLM provider to use. Defaults to openai."
+    )
+    parser.add_argument(
         "--llm", "-l",
         type=str,
         default="gpt-5-nano",
-        help="OpenAI LLM model to use"
+        help="Default LLM model to use"
+    )
+    parser.add_argument(
+        "--node-model",
+        action="append",
+        default=[],
+        metavar="NODE=MODEL",
+        help=(
+            "Override the model for a graph node. Can be repeated. "
+            "Nodes: supervisor, schemaInference, parser_agent, refinement_agent, validator_agent."
+        )
     )
     parser.add_argument(
         "--max-concurrency",
@@ -630,6 +681,8 @@ if __name__ == "__main__":
         input_path=args.input,
         outdir=args.outdir,
         dataset_id=args.dataset_id,
+        provider=args.provider,
         llm=args.llm,
+        node_models=parse_node_model_overrides(args.node_model),
         max_concurrency=args.max_concurrency,
     )

--- a/metamorph/mainConcurrent.py
+++ b/metamorph/mainConcurrent.py
@@ -6,12 +6,12 @@ from pathlib import Path
 from typing import Sequence
 
 try:
-    from metamorph.core import DEFAULT_OUTDIR, run_MetaMorph_on_csv
+    from metamorph.core import DEFAULT_OUTDIR, parse_node_model_overrides, run_MetaMorph_on_csv
 except ModuleNotFoundError:
     # Support the documented direct script form:
     # `python metamorph/mainConcurrent.py ...`
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-    from metamorph.core import DEFAULT_OUTDIR, run_MetaMorph_on_csv
+    from metamorph.core import DEFAULT_OUTDIR, parse_node_model_overrides, run_MetaMorph_on_csv
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -36,11 +36,27 @@ def build_parser() -> argparse.ArgumentParser:
         help=f"Output directory for the generated report files. Defaults to {DEFAULT_OUTDIR}/.",
     )
     parser.add_argument(
+        "--provider",
+        default="openai",
+        choices=["openai", "groq"],
+        help="LLM provider to use. Defaults to openai.",
+    )
+    parser.add_argument(
         "--llm",
         "-l",
         type=str,
         default="gpt-5-nano",
-        help="OpenAI LLM model to use.",
+        help="Default LLM model to use.",
+    )
+    parser.add_argument(
+        "--node-model",
+        action="append",
+        default=[],
+        metavar="NODE=MODEL",
+        help=(
+            "Override the model for a graph node. Can be repeated. "
+            "Nodes: supervisor, schemaInference, parser_agent, refinement_agent, validator_agent."
+        ),
     )
     parser.add_argument(
         "--max-concurrency",
@@ -57,7 +73,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         input_path=args.input,
         outdir=args.outdir,
         dataset_id=args.dataset_id,
+        provider=args.provider,
         llm=args.llm,
+        node_models=parse_node_model_overrides(args.node_model),
         max_concurrency=args.max_concurrency,
     )
     return 0

--- a/metamorph/mcp_server.py
+++ b/metamorph/mcp_server.py
@@ -9,18 +9,22 @@ def metamorph_run(
     input_path: str,
     outdir: str,
     dataset_id: str | None = None,
+    provider: str = "openai",
     llm: str = "gpt-5-nano",
+    node_models: dict[str, str] | None = None,
     max_concurrency: int = 2,
 ) -> dict:
     """
     Run MetaMorph on a CSV file and write outputs to outdir.
-    Returns paths to cleaned CSV + reports, plus a short markdown preview.
+    Returns paths to cleaned CSV, reports, run manifest, plus a short markdown preview.
     """
     res = run_MetaMorph_on_csv(
         input_path=input_path,
         outdir=outdir,
         dataset_id=dataset_id,
+        provider=provider,
         llm=llm,
+        node_models=node_models,
         max_concurrency=max_concurrency,
     )
     return {
@@ -43,7 +47,8 @@ def metamorph_info() -> dict:
         "name": "MetaMorph",
         "purpose": "Transform messy CSV metadata into clean structured outputs + reports",
         "inputs": ["CSV path"],
-        "outputs": ["cleaned CSV", "markdown report", "html report"],
+        "providers": ["openai", "groq"],
+        "outputs": ["cleaned CSV", "markdown report", "html report", "run manifest"],
     }
 
 if __name__ == "__main__":

--- a/metamorph/meta_parser.py
+++ b/metamorph/meta_parser.py
@@ -82,7 +82,7 @@ async def parser_node(state: MetaMorphState) -> Command[Literal["supervisor"]]:
     #response = await llm.with_structured_output(
     #    StructureParserOutput
      #   ).ainvoke(messages)
-    llm = get_llm()
+    llm = get_llm("parser_agent")
     
     r = llm.with_structured_output(StructureParserOutput)
     response = await ainvoke_with_backoff(r, messages)
@@ -121,4 +121,3 @@ async def parser_node(state: MetaMorphState) -> Command[Literal["supervisor"]]:
 
 
     return Command(update=P_PATCH, goto="supervisor")
-

--- a/metamorph/refinement.py
+++ b/metamorph/refinement.py
@@ -62,7 +62,7 @@ async def refinement_agent(state: MetaMorphState) -> Command:
         {"role": "system", "content": refinement_prompt},
         {"role": "user", "content": user_message}
     ]
-    llm = get_llm()
+    llm = get_llm("refinement_agent")
 
     try:
         r = llm.with_structured_output(Refinement, method="function_calling")

--- a/metamorph/schema_inference.py
+++ b/metamorph/schema_inference.py
@@ -42,7 +42,7 @@ async def schema_inference_node(state: MetaMorphState) -> Command[Literal["super
             "content": payload
         } 
     ]
-    llm = get_llm()
+    llm = get_llm("schemaInference")
 
     r = llm.with_structured_output(SchemaInference)
     response = await ainvoke_with_backoff(r, messages)
@@ -79,4 +79,3 @@ async def schema_inference_node(state: MetaMorphState) -> Command[Literal["super
         update=SI_PATCH,
         goto="supervisor"
     )
-

--- a/metamorph/supervisor.py
+++ b/metamorph/supervisor.py
@@ -82,7 +82,7 @@ async def supervisor_node(state: MetaMorphState) -> Command: #update with names 
         {"role": "system", "content": Supervisor_system_prompt},
         {"role": "user", "content" : event_context}
     ]
-    llm = get_llm()
+    llm = get_llm("supervisor")
 
     r = llm.with_structured_output(Supervisor)
     response = await ainvoke_with_backoff(r, messages)

--- a/metamorph/validator.py
+++ b/metamorph/validator.py
@@ -140,7 +140,7 @@ async def validator_node(state: MetaMorphState) -> Command:
     
     # Initialize defaults so later code never references undefined names
     decision, reason, conf, failed_rows = None, None, 0.0, []
-    llm = get_llm()
+    llm = get_llm("validator_agent")
 
     model_error = False
 

--- a/tests/test_core_runner.py
+++ b/tests/test_core_runner.py
@@ -17,6 +17,20 @@ from utils.MetaMorphState import tracker
 
 
 class CoreRunnerTests(unittest.TestCase):
+    def test_parse_node_model_overrides(self):
+        self.assertEqual(
+            core.parse_node_model_overrides(
+                ["schemaInference=schema-model", "parser_agent=parser-model"]
+            ),
+            {
+                "schemaInference": "schema-model",
+                "parser_agent": "parser-model",
+            },
+        )
+
+        with self.assertRaises(ValueError):
+            core.parse_node_model_overrides(["unknown=model"])
+
     def test_runner_uses_parameters_and_default_output_dir(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -52,11 +66,7 @@ class CoreRunnerTests(unittest.TestCase):
             old_cwd = Path.cwd()
             try:
                 os.chdir(tmp_path)
-                with (
-                    patch.object(core, "set_llm_model") as set_llm_model,
-                    patch.object(core, "get_llm", return_value=SimpleNamespace(model_name="fake-model")),
-                    patch.object(core, "run_all", side_effect=fake_run_all),
-                ):
+                with patch.object(core, "run_all", side_effect=fake_run_all):
                     result = core.run_MetaMorph_on_csv(
                         input_path=input_path,
                         llm="test-model",
@@ -65,9 +75,8 @@ class CoreRunnerTests(unittest.TestCase):
             finally:
                 os.chdir(old_cwd)
 
-            set_llm_model.assert_called_once_with("test-model")
             self.assertEqual(result.dataset_id, "sample_metadata")
-            self.assertEqual(result.model, "fake-model")
+            self.assertEqual(result.model, "test-model")
             self.assertEqual(captured["dataset_id"], "sample_metadata")
             self.assertEqual(captured["columns"], {"height": ["5 ft 10 in", "170 cm"]})
             self.assertEqual(captured["max_concurrency"], 7)
@@ -103,11 +112,7 @@ class CoreRunnerTests(unittest.TestCase):
                     },
                 )
 
-            with (
-                patch.object(core, "set_llm_model"),
-                patch.object(core, "get_llm", return_value=SimpleNamespace(model_name="fake-model")),
-                patch.object(core, "run_all", side_effect=fake_run_all),
-            ):
+            with patch.object(core, "run_all", side_effect=fake_run_all):
                 result = core.run_MetaMorph_on_csv(
                     input_path=input_path,
                     outdir=outdir,
@@ -149,16 +154,14 @@ class CoreRunnerTests(unittest.TestCase):
                     },
                 )
 
-            with (
-                patch.object(core, "set_llm_model"),
-                patch.object(core, "get_llm", return_value=SimpleNamespace(model_name="fake-model")),
-                patch.object(core, "run_all", side_effect=fake_run_all),
-            ):
+            with patch.object(core, "run_all", side_effect=fake_run_all):
                 result = core.run_MetaMorph_on_csv(
                     input_path=input_path,
                     outdir=outdir,
                     dataset_id="dataset-a",
+                    provider="groq",
                     llm="test-model",
+                    node_models={"parser_agent": "parser-model"},
                     max_concurrency=3,
                 )
 
@@ -169,9 +172,11 @@ class CoreRunnerTests(unittest.TestCase):
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             self.assertEqual(manifest["dataset_id"], "dataset-a")
             self.assertEqual(manifest["input_path"], str(input_path.resolve()))
-            self.assertEqual(manifest["model"], "fake-model")
+            self.assertEqual(manifest["model"], "test-model")
+            self.assertEqual(manifest["config"]["provider"], "groq")
             self.assertEqual(manifest["config"]["requested_model"], "test-model")
-            self.assertEqual(manifest["config"]["resolved_model"], "fake-model")
+            self.assertEqual(manifest["config"]["resolved_model"], "test-model")
+            self.assertEqual(manifest["config"]["node_models"], {"parser_agent": "parser-model"})
             self.assertEqual(manifest["config"]["max_concurrency"], 3)
             self.assertEqual(manifest["summary"]["total_retry_count"], 1)
             self.assertEqual(manifest["columns"]["age"]["validation_status"], "pass")
@@ -205,8 +210,12 @@ class CliTests(unittest.TestCase):
                     "dataset-a",
                     "--outdir",
                     "outputs",
+                    "--provider",
+                    "groq",
                     "--llm",
                     "test-model",
+                    "--node-model",
+                    "parser_agent=parser-model",
                     "--max-concurrency",
                     "4",
                 ]
@@ -217,7 +226,9 @@ class CliTests(unittest.TestCase):
             input_path="examples/data1.csv",
             outdir="outputs",
             dataset_id="dataset-a",
+            provider="groq",
             llm="test-model",
+            node_models={"parser_agent": "parser-model"},
             max_concurrency=4,
         )
 
@@ -240,7 +251,9 @@ class McpServerTests(unittest.TestCase):
                 input_path="input.csv",
                 outdir="outputs",
                 dataset_id=None,
+                provider="groq",
                 llm="test-model",
+                node_models={"parser_agent": "parser-model"},
                 max_concurrency=3,
             )
 
@@ -248,7 +261,9 @@ class McpServerTests(unittest.TestCase):
             input_path="input.csv",
             outdir="outputs",
             dataset_id=None,
+            provider="groq",
             llm="test-model",
+            node_models={"parser_agent": "parser-model"},
             max_concurrency=3,
         )
         self.assertEqual(result["dataset_id"], "dataset-a")

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,54 @@
+import unittest
+
+from utils.llm import (
+    LLMClientProvider,
+    LLMProviderConfig,
+    get_llm,
+    set_llm_model,
+    use_llm_provider,
+)
+
+
+class LlmProviderTests(unittest.TestCase):
+    def test_provider_resolves_default_and_node_model_overrides(self):
+        calls = []
+
+        def fake_factory(provider, model, node_name):
+            calls.append((provider, model, node_name))
+            return {"provider": provider, "model": model, "node_name": node_name}
+
+        provider = LLMClientProvider(
+            LLMProviderConfig(
+                provider="groq",
+                default_model="llama-default",
+                node_models={"parser_agent": "llama-parser"},
+            ),
+            client_factory=fake_factory,
+        )
+
+        with use_llm_provider(provider):
+            self.assertEqual(get_llm("schemaInference")["model"], "llama-default")
+            self.assertEqual(get_llm("parser_agent")["model"], "llama-parser")
+            self.assertIs(get_llm("parser_agent"), get_llm("parser_agent"))
+
+        self.assertEqual(
+            calls,
+            [
+                ("groq", "llama-default", "schemaInference"),
+                ("groq", "llama-parser", "parser_agent"),
+            ],
+        )
+
+    def test_set_llm_model_preserves_openai_default_compatibility(self):
+        provider = set_llm_model("gpt-test")
+
+        self.assertEqual(provider.provider, "openai")
+        self.assertEqual(provider.default_model, "gpt-test")
+
+    def test_unknown_provider_is_rejected(self):
+        with self.assertRaises(ValueError):
+            LLMProviderConfig(provider="unknown", default_model="model")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -1,36 +1,128 @@
-from langchain_core.runnables import Runnable
-from langchain_openai import ChatOpenAI
-from dotenv import load_dotenv
-#from langchain_groq import ChatGroq
+from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Callable, Mapping
 import random
-from openai import RateLimitError, APIError, APITimeoutError
-import os
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from openai import APIError, APITimeoutError, RateLimitError
 
 load_dotenv()
 
-_LLM_MODEL = None
-_LLM_INSTANCE = None
+SUPPORTED_PROVIDERS = {"openai", "groq"}
+
+
+@dataclass(frozen=True)
+class LLMProviderConfig:
+    provider: str = "openai"
+    default_model: str = "gpt-5-nano"
+    node_models: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self):
+        provider = self.provider.lower()
+        if provider not in SUPPORTED_PROVIDERS:
+            supported = ", ".join(sorted(SUPPORTED_PROVIDERS))
+            raise ValueError(f"Unsupported LLM provider '{self.provider}'. Supported providers: {supported}.")
+        object.__setattr__(self, "provider", provider)
+        object.__setattr__(self, "node_models", dict(self.node_models or {}))
+
+
+LLMClientFactory = Callable[[str, str, str | None], object]
+
+
+class LLMClientProvider:
+    def __init__(
+        self,
+        config: LLMProviderConfig,
+        client_factory: LLMClientFactory | None = None,
+    ):
+        self.config = config
+        self._client_factory = client_factory
+        self._clients: dict[tuple[str, str], object] = {}
+
+    @property
+    def provider(self) -> str:
+        return self.config.provider
+
+    @property
+    def default_model(self) -> str:
+        return self.config.default_model
+
+    def resolve_model(self, node_name: str | None = None) -> str:
+        if node_name and node_name in self.config.node_models:
+            return self.config.node_models[node_name]
+        return self.config.default_model
+
+    def get_llm(self, node_name: str | None = None):
+        model = self.resolve_model(node_name)
+        key = (self.config.provider, model)
+        if key not in self._clients:
+            if self._client_factory:
+                self._clients[key] = self._client_factory(self.config.provider, model, node_name)
+            else:
+                self._clients[key] = build_llm_client(self.config.provider, model)
+        return self._clients[key]
+
+
+def build_llm_client(provider: str, model: str):
+    provider = provider.lower()
+    if provider == "openai":
+        return ChatOpenAI(model=model)
+    if provider == "groq":
+        from langchain_groq import ChatGroq
+
+        return ChatGroq(model=model)
+    supported = ", ".join(sorted(SUPPORTED_PROVIDERS))
+    raise ValueError(f"Unsupported LLM provider '{provider}'. Supported providers: {supported}.")
+
+
+_CURRENT_PROVIDER: ContextVar[LLMClientProvider | None] = ContextVar("metamorph_llm_provider", default=None)
+_GLOBAL_PROVIDER: LLMClientProvider | None = None
+
+
+def set_llm_provider(
+    provider: str = "openai",
+    model: str = "gpt-5-nano",
+    node_models: Mapping[str, str] | None = None,
+) -> LLMClientProvider:
+    global _GLOBAL_PROVIDER
+    _GLOBAL_PROVIDER = LLMClientProvider(
+        LLMProviderConfig(
+            provider=provider,
+            default_model=model,
+            node_models=node_models or {},
+        )
+    )
+    return _GLOBAL_PROVIDER
+
 
 def set_llm_model(model_name: str):
-    global _LLM_MODEL, _LLM_INSTANCE
-    _LLM_MODEL = model_name
-    _LLM_INSTANCE = None  # reset if model changes
-
-def get_llm():
-    global _LLM_INSTANCE
-    if not _LLM_MODEL:
-        raise ValueError("LLM model not set. Call set_llm_model(...) before get_llm().")
-    if _LLM_INSTANCE is None:
-        _LLM_INSTANCE = ChatOpenAI(model=_LLM_MODEL) #removed temperature.
-    return _LLM_INSTANCE
+    return set_llm_provider(provider="openai", model=model_name)
 
 
-#dynamic implementation, say user wants groq over chatgpt
+@contextmanager
+def use_llm_provider(provider: LLMClientProvider):
+    token = _CURRENT_PROVIDER.set(provider)
+    try:
+        yield provider
+    finally:
+        _CURRENT_PROVIDER.reset(token)
 
 
-#Rate limits for LLM API calls 
+def get_llm_provider() -> LLMClientProvider:
+    provider = _CURRENT_PROVIDER.get() or _GLOBAL_PROVIDER
+    if provider is None:
+        raise ValueError("LLM provider not set. Configure one before calling get_llm().")
+    return provider
+
+
+def get_llm(node_name: str | None = None):
+    return get_llm_provider().get_llm(node_name=node_name)
+
 
 async def ainvoke_with_backoff(runnable, *args, max_retries=8, base_delay=0.5, max_delay=10.0, jitter=0.2, **kwargs):
     """
@@ -39,7 +131,7 @@ async def ainvoke_with_backoff(runnable, *args, max_retries=8, base_delay=0.5, m
     for attempt in range(max_retries + 1):
         try:
             return await runnable.ainvoke(*args, **kwargs)
-        except RateLimitError as e:
+        except RateLimitError:
             if attempt == max_retries:
                 raise
 
@@ -47,14 +139,10 @@ async def ainvoke_with_backoff(runnable, *args, max_retries=8, base_delay=0.5, m
             delay = delay + random.uniform(0, jitter)
             await asyncio.sleep(delay)
 
-        except (APITimeoutError, APIError) as e:
+        except (APITimeoutError, APIError):
             if attempt == max_retries:
                 raise
 
             delay = min(max_delay, base_delay * (2 ** attempt))
             delay = delay + random.uniform(0, jitter)
             await asyncio.sleep(delay)
-
-            
-
-


### PR DESCRIPTION
## Summary
- replace the global OpenAI-only singleton path with a run-scoped LLM provider object
- support OpenAI and Groq client construction with a shared structured-output interface
- add per-node model overrides for supervisor, schemaInference, parser_agent, refinement_agent, and validator_agent
- thread provider/node model config through CLI, MCP, run config, and run.json
- update nodes to request LLM clients by node name
- document provider credentials and CLI usage

## Verification
- pixi run python -m unittest discover -s tests
- pixi run python metamorph/mainConcurrent.py --help

Closes #35